### PR TITLE
docs(readme): replace inline styled spans with local SVG badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,12 @@
 </p>
 
 <p align="center">
-  <span style="display:inline-block;padding:.25em .6em;border-radius:999px;background:#1f6feb1a;color:#58a6ff;font-size:12px;">Protocol Terminator</span>
-  <span style="display:inline-block;padding:.25em .6em;border-radius:999px;background:#2386361a;color:#3fb950;font-size:12px;">GameGuard Heartbeat</span>
-  <span style="display:inline-block;padding:.25em .6em;border-radius:999px;background:#8957e51a;color:#d2a8ff;font-size:12px;">OpenKore Query Server</span>
-  <span style="display:inline-block;padding:.25em .6em;border-radius:999px;background:#9e6a031a;color:#e3b341;font-size:12px;">Pluggable Seed/Checksum</span>
+  <img src="docs/badges/protocol-terminator.svg" alt="Protocol Terminator">
+  <img src="docs/badges/gameguard-heartbeat.svg" alt="GameGuard Heartbeat">
+  <img src="docs/badges/openkore-query-server.svg" alt="OpenKore Query Server">
+  <img src="docs/badges/pluggable-seed-checksum.svg" alt="Pluggable Seed/Checksum">
 </p>
+
 
 
 ## コンセプト / Concept

--- a/docs/badges/gameguard-heartbeat.svg
+++ b/docs/badges/gameguard-heartbeat.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="196" height="24" role="img" aria-label="GameGuard Heartbeat">
+  <rect rx="12" width="196" height="24" fill="#238636" fill-opacity="0.10"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle"
+        font-family="Segoe UI, Ubuntu, Arial, sans-serif" font-size="12" fill="#3fb950">
+    GameGuard Heartbeat
+  </text>
+</svg>

--- a/docs/badges/openkore-query-server.svg
+++ b/docs/badges/openkore-query-server.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="214" height="24" role="img" aria-label="OpenKore Query Server">
+  <rect rx="12" width="214" height="24" fill="#8957e5" fill-opacity="0.10"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle"
+        font-family="Segoe UI, Ubuntu, Arial, sans-serif" font-size="12" fill="#d2a8ff">
+    OpenKore Query Server
+  </text>
+</svg>

--- a/docs/badges/pluggable-seed-checksum.svg
+++ b/docs/badges/pluggable-seed-checksum.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="234" height="24" role="img" aria-label="Pluggable Seed/Checksum">
+  <rect rx="12" width="234" height="24" fill="#9e6a03" fill-opacity="0.10"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle"
+        font-family="Segoe UI, Ubuntu, Arial, sans-serif" font-size="12" fill="#e3b341">
+    Pluggable Seed/Checksum
+  </text>
+</svg>

--- a/docs/badges/protocol-terminator.svg
+++ b/docs/badges/protocol-terminator.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="24" role="img" aria-label="Protocol Terminator">
+  <rect rx="12" width="180" height="24" fill="#1f6feb" fill-opacity="0.10"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle"
+        font-family="Segoe UI, Ubuntu, Arial, sans-serif" font-size="12" fill="#58a6ff">
+    Protocol Terminator
+  </text>
+</svg>


### PR DESCRIPTION
GitHub sanitizes inline styles in README HTML, causing the colored “pill”
badges to render as plain text. This change replaces the <span> badges with
local SVG images that reliably render on GitHub.

- Add docs/badges/*.svg (protocol-terminator, gameguard-heartbeat,
  openkore-query-server, pluggable-seed-checksum)
- Update README to reference the new SVG badges
- Remove inline-style <span> badges