### PR TITLE
release(v0.1.3):  UI polish + GG bridge retries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,8 @@ add_executable(Thanatos
   src/infrastructure/net/asio/AsioTcpServer.cpp
   src/infrastructure/net/asio/AsioTcpClient.cpp
   src/infrastructure/presentation/StartupSummary.cpp
+  src/infrastructure/presentation/StartupSummary.cpp
+  src/infrastructure/terminal/Console.cpp
 
   # Shared states
   src/application/state/SessionRegistry.cpp

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ service_name = "Thanatos"
 
 # Semantic version of your build
 # ビルドのセマンティックバージョン
-version      = "0.1.2"
+version      = "0.1.3"
 
 # Verbose checks and extra diagnostics (disable in production)
 # 詳細チェックと追加診断（本番では無効に）

--- a/config/thanatos.toml
+++ b/config/thanatos.toml
@@ -1,7 +1,7 @@
 [app]
 service_name = "Thanatos"
-version      = "0.1.2"
-debug        = true
+version      = "0.1.3"
+debug        = false
 
 [thanatos]
 ro_host     = "127.0.0.1"

--- a/resources/thanatos.rc
+++ b/resources/thanatos.rc
@@ -52,11 +52,11 @@ BEGIN
     BEGIN
       VALUE "CompanyName",      "Arkan Software"
       VALUE "FileDescription",  "Thanatos Developed by Rhayden RO GameGuard Handshake Proxy"
-      VALUE "FileVersion",      "0.1.2"
+      VALUE "FileVersion",      "0.1.3"
       VALUE "InternalName",     "Thanatos"
       VALUE "OriginalFilename", "Thanatos.exe"
       VALUE "ProductName",      "Thanatos"
-      VALUE "ProductVersion",   "0.1.2"
+      VALUE "ProductVersion",   "0.1.3"
       // Optional fields / 任意項目:
       // VALUE "LegalCopyright",   "© 2025 Arkan Software. All rights reserved."
       // VALUE "LegalTrademarks",  "Ragnarok Online is a trademark of Gravity Co., Ltd."

--- a/src/application/services/GameGuardBridge.hpp
+++ b/src/application/services/GameGuardBridge.hpp
@@ -86,9 +86,7 @@ class GameGuardBridge
     GGStrategy strategy_{GGStrategy::FULL_FRAME};  // default
     std::size_t last_gg_request_len_{0};           // last 09CF total length
 
-    // =========================================================================
     // Retry and randomization
-    // =========================================================================
     int retry_count_{0};                       // Attempt counter
     int max_retries_{3};                       // Maximum attempts (default: 3)
     std::vector<std::uint8_t> last_gg_query_;  // Last packet sent (for retry)

--- a/src/application/services/GameGuardBridge.hpp
+++ b/src/application/services/GameGuardBridge.hpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <random>
 #include <vector>
 
 #include "application/ports/net/IClientWire.hpp"
@@ -16,8 +17,6 @@ class GameGuardBridge
    public:
     using Clock = std::chrono::steady_clock;
 
-    // How to build the Poseidon reply from the client's 09D0 frame.
-    // クライアントからの 09D0 フレームをどう返信に組み立てるかの戦略。
     enum class GGStrategy
     {
         FULL_FRAME,     // Send full 09D0 frame (RagnarokServer.pm behavior)
@@ -40,20 +39,36 @@ class GameGuardBridge
 
     void set_timeout(std::chrono::milliseconds ms)
     {
+        base_timeout_ = ms;
         timeout_ = ms;
     }
+
     void set_size_bounds(std::size_t min, std::size_t max)
     {
         min_len_ = min;
         max_len_ = max;
     }
+
     void set_greedy_window(std::chrono::milliseconds ms)
     {
         greedy_window_ = ms;
-    }  // legacy
+    }
+
     void set_strategy(GGStrategy s)
     {
         strategy_ = s;
+    }
+
+    void set_max_retries(int max_retries)
+    {
+        max_retries_ = max_retries;
+    }
+
+    void set_timeout_randomization(bool enabled, int min_percent = 80, int max_percent = 120)
+    {
+        randomize_timeout_ = enabled;
+        timeout_min_percent_ = min_percent;
+        timeout_max_percent_ = max_percent;
     }
 
    private:
@@ -71,7 +86,23 @@ class GameGuardBridge
     GGStrategy strategy_{GGStrategy::FULL_FRAME};  // default
     std::size_t last_gg_request_len_{0};           // last 09CF total length
 
+    // =========================================================================
+    // Retry and randomization
+    // =========================================================================
+    int retry_count_{0};                       // Attempt counter
+    int max_retries_{3};                       // Maximum attempts (default: 3)
+    std::vector<std::uint8_t> last_gg_query_;  // Last packet sent (for retry)
+
+    std::chrono::milliseconds base_timeout_{1500};  // Timeout base (no randomization)
+    bool randomize_timeout_{false};                 // Whether to randomize the timeout
+    int timeout_min_percent_{80};                   // Minimum: 80% of base timeout
+    int timeout_max_percent_{120};                  // Maximum: 120% of base timeout
+
+    std::mt19937 rng_{std::random_device{}()};  // Random number generator
+
     void on_query_from_kore_(std::vector<std::uint8_t> gg_query);
+
+    std::chrono::milliseconds get_randomized_timeout();
 };
 
 }  // namespace arkan::thanatos::application::services

--- a/src/infrastructure/config/Config.hpp
+++ b/src/infrastructure/config/Config.hpp
@@ -13,7 +13,7 @@ struct Config
 {
     // ===== app =====
     std::string service_name = "Thanatos";
-    std::string version = "0.1.2";
+    std::string version = "0.1.3";
     bool debug = false;
 
     // ===== logging =====

--- a/src/infrastructure/presentation/CardBuilder.hpp
+++ b/src/infrastructure/presentation/CardBuilder.hpp
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "shared/terminal/Ansi.hpp"
+#include "shared/terminal/TextWidth.hpp"
+#include "shared/terminal/Utf8.hpp"
+
+#if defined(_WIN32)
+#ifdef max
+#undef max
+#endif
+#ifdef min
+#undef min
+#endif
+#endif
+
+namespace arkan::thanatos::infrastructure::presentation
+{
+namespace term = arkan::thanatos::shared::terminal;
+namespace ansi = arkan::thanatos::shared::ansi;
+
+// Simple theme shared by all cards.
+// すべてのカードで共有する簡易テーマ。
+struct BannerTheme
+{
+    bool color{true};
+    bool utf8_box{true};
+    int pad_lr{2};
+    std::string accent = std::string(ansi::green);
+    std::string reset = std::string(ansi::reset);
+};
+
+// Helper to render consistent framed cards.
+// 一貫した枠付きカードを描画するヘルパー。
+class CardBuilder
+{
+   public:
+    CardBuilder(BannerTheme t, int inner_width) : theme_(std::move(t)), inner_(inner_width) {}
+
+    // total width including inner padding (no side glyphs)
+    // 内側パディング込みの実幅（左右罫線は含まない）
+    int box_width() const
+    {
+        return inner_ + theme_.pad_lr * 2;
+    }
+
+    std::string top() const
+    {
+        const int bw = box_width();
+        return theme_.utf8_box ? "┌" + term::repeat_utf8("─", bw) + "┐"
+                               : "+" + std::string(static_cast<size_t>(bw), '-') + "+";
+    }
+
+    std::string sep() const
+    {
+        const int bw = box_width();
+        return theme_.utf8_box ? "├" + term::repeat_utf8("─", bw) + "┤"
+                               : "+" + std::string(static_cast<size_t>(bw), '-') + "+";
+    }
+
+    std::string bot() const
+    {
+        const int bw = box_width();
+        return theme_.utf8_box ? "└" + term::repeat_utf8("─", bw) + "┘"
+                               : "+" + std::string(static_cast<size_t>(bw), '-') + "+";
+    }
+
+    std::string wrap(const std::string& s) const
+    {
+        return (theme_.utf8_box ? "│" : "|") + s + (theme_.utf8_box ? "│" : "|");
+    }
+
+    std::string pad(const std::string& raw) const
+    {
+        const int vis = static_cast<int>(term::visible_width_utf8(term::strip_ansi(raw)));
+        const int pad = (std::max)(0, inner_ - vis);
+        return std::string(static_cast<size_t>(theme_.pad_lr), ' ') + raw +
+               std::string(static_cast<size_t>(pad), ' ') +
+               std::string(static_cast<size_t>(theme_.pad_lr), ' ');
+    }
+
+    std::string centered_title(const std::string& title) const
+    {
+        const int tw = static_cast<int>(term::visible_width_utf8(term::strip_ansi(title)));
+        const int pad_total = (std::max)(0, inner_ - (tw + 2));  // spaces around title
+        const int left = pad_total / 2;
+        const int right = pad_total - left;
+
+        const std::string leftFill = theme_.utf8_box ? term::repeat_utf8("─", left)
+                                                     : std::string(static_cast<size_t>(left), '-');
+        const std::string rightFill = theme_.utf8_box
+                                          ? term::repeat_utf8("─", right)
+                                          : std::string(static_cast<size_t>(right), '-');
+
+        return wrap(std::string(static_cast<size_t>(theme_.pad_lr), ' ') + theme_.accent +
+                    leftFill + theme_.reset + " " + title + " " + theme_.accent + rightFill +
+                    theme_.reset + std::string(static_cast<size_t>(theme_.pad_lr), ' '));
+    }
+
+    int inner_width() const
+    {
+        return inner_;
+    }
+
+   private:
+    BannerTheme theme_;
+    int inner_;
+};
+
+// Compute max visible width among lines.
+// 複数行の見かけ幅の最大値を算出。
+inline int max_visible_width(const std::vector<std::string>& lines)
+{
+    int m = 0;
+    for (const auto& s : lines)
+    {
+        const int w = static_cast<int>(term::visible_width_utf8(term::strip_ansi(s)));
+        m = (std::max)(m, w);
+    }
+    return m;
+}
+
+}  // namespace arkan::thanatos::infrastructure::presentation

--- a/src/infrastructure/presentation/StartupSummary.cpp
+++ b/src/infrastructure/presentation/StartupSummary.cpp
@@ -1,21 +1,17 @@
 #include "infrastructure/presentation/StartupSummary.hpp"
 
 #include <algorithm>
-#include <cstdio>
-#include <cstdlib>
 #include <string>
-#include <string_view>
+#include <vector>
 
-#include "shared/BannerPrinter.hpp"
+#include "infrastructure/presentation/CardBuilder.hpp"
+#include "infrastructure/terminal/Output.hpp"
+#include "shared/terminal/Ansi.hpp"
+#include "shared/terminal/TextWidth.hpp"
 
+// Defuse possible Windows max/min macros.
+// Windows の max/min マクロ衝突を回避。
 #if defined(_WIN32)
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <windows.h>
 #ifdef max
 #undef max
 #endif
@@ -26,188 +22,90 @@
 
 namespace arkan::thanatos::infrastructure::presentation
 {
+namespace ansi = arkan::thanatos::shared::ansi;
+namespace term = arkan::thanatos::shared::terminal;
+using arkan::thanatos::infrastructure::terminal::emit_blank_line;
+using arkan::thanatos::infrastructure::terminal::emit_utf8_line;
 
-// ---- visible length without ANSI / ANSI を除いた見かけの長さ ----
-static std::string strip_ansi(std::string_view s)
+// Visible width helper (terminal columns).
+// 端末上の見かけ幅を取得。
+static inline int vis_cols(const std::string& s)
 {
-    std::string out;
-    out.reserve(s.size());
-    for (size_t i = 0; i < s.size(); ++i)
-    {
-        if (s[i] == '\x1b')
-        {
-            ++i;
-            if (i < s.size() && s[i] == '[')
-                while (i < s.size() && s[i] != 'm') ++i;
-            continue;
-        }
-        out.push_back(s[i]);
-    }
-    return out;
-}
-static inline size_t vis_len(const std::string& s)
-{
-    return strip_ansi(s).size();
+    return static_cast<int>(term::visible_width_utf8(term::strip_ansi(s)));
 }
 
-// ---- console capability ----
-#if defined(_WIN32)
-static bool console_utf8_ok()
+void print_startup_summary(const StartupSummary& s, bool color, bool utf8Box,
+                           int align_to_inner_cols)
 {
-    HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
-    DWORD mode;
-    return (h != INVALID_HANDLE_VALUE) && GetConsoleMode(h, &mode);
-}
-#else
-static bool console_utf8_ok()
-{
-    // qualify the function from BannerPrinter.hpp
-    return arkan::thanatos::shared::locale_is_utf8();
-}
-#endif
-
-// ---- emit one line (UTF-8 on POSIX, UTF-16 on Win) ----
-static void emit_utf8_line(std::string_view utf8)
-{
-#if defined(_WIN32)
-    arkan::thanatos::shared::print_utf8_banner(std::string(utf8));
-    arkan::thanatos::shared::print_utf8_banner(std::string("\r\n"));
-#else
-    std::fwrite(utf8.data(), 1, utf8.size(), stdout);
-    std::fwrite("\n", 1, 1, stdout);
-#endif
-}
-
-// --- repeats a UTF-8 "glyph" n times ---
-static std::string repeat_utf8(std::string_view g, size_t n)
-{
-    std::string out;
-    out.reserve(g.size() * n);
-    for (size_t i = 0; i < n; ++i) out += g;
-    return out;
-}
-
-static void emit_ascii_line(std::string_view ascii)
-{
-    std::fwrite(ascii.data(), 1, ascii.size(), stdout);
-    std::fwrite("\n", 1, 1, stdout);
-}
-
-void print_startup_summary(const StartupSummary& s)
-{
-    const bool utf8 = console_utf8_ok();
-    const bool color = s.color && utf8;
-
-    // --- Decide frame style (robust default on Windows = ASCII) --------------
-#if defined(_WIN32)
-    bool fancy_box = false;
-#else
-    bool fancy_box = true;
-#endif
-    if (const char* env = std::getenv("THANATOS_UTF8_BOX"))
-    {
-        if (env[0] == '1') fancy_box = true;
-        if (env[0] == '0') fancy_box = false;
-    }
-
-    if (s.prefer_utf8_box) fancy_box = true;
-
-    // colors
-    const char* BOLD = color ? "\x1b[1m" : "";
-    const char* GREEN = color ? "\x1b[32m" : "";
-    const char* CYAN = color ? "\x1b[36m" : "";
-    const char* YELLOW = color ? "\x1b[33m" : "";
-    const char* MAG = color ? "\x1b[35m" : "";
-    const char* RESET = color ? "\x1b[0m" : "";
+    // Color tokens (empty when color == false).
+    // 色トークン（color=false の時は空文字）。
+    const std::string BOLD = color ? std::string(ansi::bold) : "";
+    const std::string DIM = color ? std::string(ansi::dim) : "";
+    const std::string RED = color ? std::string(ansi::red) : "";
+    const std::string GREEN = color ? std::string(ansi::green) : "";
+    const std::string CYAN = color ? std::string(ansi::cyan) : "";
+    const std::string YELLOW = color ? std::string(ansi::yellow) : "";
+    const std::string RESET = color ? std::string(ansi::reset) : "";
 
     auto ep = [](const std::string& h, std::uint16_t p) { return h + ":" + std::to_string(p); };
 
-    // lines (content only) / 内容行
-    const std::string title = "Thanatos Online";
-    auto line_idx = std::string(CYAN) + "Selected port set index" + RESET + " : " + BOLD +
-                    std::to_string(s.set_index) + RESET;
-    auto line_login = std::string(CYAN) + "RO Login " + RESET + ": " + YELLOW +
-                      ep(s.ro_host, s.login_port) + RESET;
-    auto line_char = std::string(CYAN) + "RO Char  " + RESET + ": " + YELLOW +
-                     ep(s.ro_host, s.char_port) + RESET;
-    auto line_bus = std::string(CYAN) + "Query BUS" + RESET + ": " + YELLOW +
-                    ep(s.query_host, s.query_port) + RESET;
-    auto line_gg = std::string(MAG) + "GG Bridge" + RESET +
-                   " : strategy=AUTO, size=[2..4096], timeout=3000ms, greedy=150ms";
+    // ── Content (no borders) / 罫線なしの本文 ───────────────────────────────
+    const std::string title_text = RED + "Thanatos" + GREEN + " Online" + RESET;
 
-    // width / 幅
-    size_t inner = 0;
-    inner = (std::max)(inner, vis_len(line_idx));
-    inner = (std::max)(inner, vis_len(line_login));
-    inner = (std::max)(inner, vis_len(line_char));
-    inner = (std::max)(inner, vis_len(line_bus));
-    inner = (std::max)(inner, vis_len(line_gg));
-    inner = (std::max)(inner, title.size() + 2);  // account for the spaces around the title
-    const size_t BOX_W = inner + 4;
+    const std::string idx = DIM +
+                            (CYAN + "Selected port set index" + RESET + " : " + BOLD +
+                             std::to_string(s.set_index) + RESET) +
+                            RESET;
 
-    if (!fancy_box)
+    // Left labels with alignment.
+    // 左側ラベルの整列。
+    const std::string L1 = CYAN + "RO Login" + RESET;
+    const std::string L2 = CYAN + "RO Char " + RESET;
+    const std::string L3 = CYAN + "Query BUS" + RESET;
+
+    const int label_w = (std::max)(vis_cols(L1), (std::max)(vis_cols(L2), vis_cols(L3)));
+    auto pad_label = [&](const std::string& lbl)
     {
-        // ---------------- ASCII frame / ASCII 罫線 ----------------
-        auto framed = [&](const std::string& c)
-        {
-            size_t pad = (vis_len(c) < inner) ? (inner - vis_len(c)) : 0;
-            return std::string("| ") + c + std::string(pad, ' ') + " |";
-        };
-
-        const std::string top = "+" + std::string(BOX_W - 2, '-') + "+";
-        const std::string sep = "+" + std::string(BOX_W - 2, '-') + "+";
-        const std::string bot = "+" + std::string(BOX_W - 2, '-') + "+";
-
-        const size_t title_len = title.size() + 2;
-        const size_t pad_total = (inner > title_len) ? (inner - title_len) : 0;
-        size_t left = pad_total / 2;
-        size_t right = pad_total - left;
-
-        std::string ttl = std::string("| ") + GREEN + std::string(left, '=') + " " + title + " " +
-                          std::string(right, '=') + RESET + " |";
-
-        emit_ascii_line(top);
-        emit_utf8_line(ttl);
-        emit_utf8_line(framed(line_idx));
-        emit_ascii_line(sep);
-        emit_utf8_line(framed(line_login));
-        emit_utf8_line(framed(line_char));
-        emit_utf8_line(framed(line_bus));
-        emit_ascii_line(sep);
-        emit_utf8_line(framed(line_gg));
-        emit_ascii_line(bot);
-        return;
-    }
-
-    // ---------------- UTF-8 box-drawing frame / UTF-8 罫線 ----------------
-    auto framed = [&](const std::string& c)
-    {
-        size_t pad = (vis_len(c) < inner) ? (inner - vis_len(c)) : 0;
-        return std::string("│ ") + c + std::string(pad, ' ') + " │";
+        const int pad = (std::max)(0, label_w - vis_cols(lbl));
+        return lbl + std::string(static_cast<size_t>(pad), ' ');
     };
 
-    const std::string top = std::string("┌") + repeat_utf8("─", BOX_W - 2) + std::string("┐");
-    const std::string sep = std::string("├") + repeat_utf8("─", BOX_W - 2) + std::string("┤");
-    const std::string bot = std::string("└") + repeat_utf8("─", BOX_W - 2) + std::string("┘");
+    const std::string login = pad_label(L1) + " : " + YELLOW + ep(s.ro_host, s.login_port) + RESET;
+    const std::string ch = pad_label(L2) + " : " + YELLOW + ep(s.ro_host, s.char_port) + RESET;
+    const std::string bus = pad_label(L3) + " : " + YELLOW + ep(s.query_host, s.query_port) + RESET;
 
-    const size_t title_len = title.size() + 2;
-    const size_t pad_total = (inner > title_len) ? (inner - title_len) : 0;
-    size_t left = pad_total / 2;
-    size_t right = pad_total - left;
+    // We intentionally omit “GG Bridge” to keep the card compact and same height as the top banner.
+    // 上段バナーと高さを揃えるため “GG Bridge” 行はあえて省略。
 
-    std::string ttl = std::string("│ ") + GREEN + repeat_utf8("─", left) + " " + title + " " +
-                      repeat_utf8("─", right) + RESET + std::string(" │");
+    // ── Width calculation / 幅計算 ─────────────────────────────────────────
+    std::vector<std::string> content_lines{title_text, idx, login, ch, bus};
+    int inner = max_visible_width(content_lines);  // computed by helper
+    if (align_to_inner_cols > 0) inner = (std::max)(inner, align_to_inner_cols);
 
-    emit_utf8_line(top);
-    emit_utf8_line(ttl);
-    emit_utf8_line(framed(line_idx));
-    emit_utf8_line(sep);
-    emit_utf8_line(framed(line_login));
-    emit_utf8_line(framed(line_char));
-    emit_utf8_line(framed(line_bus));
-    emit_utf8_line(sep);
-    emit_utf8_line(framed(line_gg));
-    emit_utf8_line(bot);
+    // ── Build themed card / テーマ付きカードを構築 ─────────────────────────
+    BannerTheme theme;
+    theme.color = color;
+    theme.utf8_box = utf8Box;
+    theme.pad_lr = 2;
+    theme.accent = color ? std::string(ansi::green) : std::string();
+    theme.reset = color ? std::string(ansi::reset) : std::string();
+
+    CardBuilder card(theme, inner);
+
+    // ── Output (no blank line before) / 出力（前に空行なし） ────────────────
+    emit_utf8_line(card.top());
+    emit_utf8_line(card.centered_title(title_text));
+    emit_utf8_line(card.sep());
+
+    emit_utf8_line(card.wrap(card.pad(idx)));
+    emit_utf8_line(card.sep());
+
+    emit_utf8_line(card.wrap(card.pad(login)));
+    emit_utf8_line(card.wrap(card.pad(ch)));
+    emit_utf8_line(card.wrap(card.pad(bus)));
+
+    emit_utf8_line(card.bot());
+    emit_blank_line();
 }
 
 }  // namespace arkan::thanatos::infrastructure::presentation

--- a/src/infrastructure/presentation/StartupSummary.hpp
+++ b/src/infrastructure/presentation/StartupSummary.hpp
@@ -6,7 +6,7 @@
 namespace arkan::thanatos::infrastructure::presentation
 {
 
-// Startup banner data / 起動サマリ用データ
+// Data used to render the card.
 struct StartupSummary
 {
     std::string ro_host;
@@ -15,12 +15,10 @@ struct StartupSummary
     std::uint16_t char_port{};
     std::uint16_t query_port{};
     std::size_t set_index{};
-    bool color{true};  // enable ANSI colors if console supports / コンソール対応時のみカラー
-    bool prefer_utf8_box{false};  // try UTF-8 box-drawing (may be overridden) / UTF-8 罫線優先
 };
 
-// Print banner to console (robust; ASCII fallback on Win) / 起動サマリをコンソールへ出力（Win では
-// ASCII を既定）
-void print_startup_summary(const StartupSummary& s);
+// Render the startup card.
+void print_startup_summary(const StartupSummary& s, bool color = true, bool utf8Box = true,
+                           int align_to_inner_cols = -1);
 
 }  // namespace arkan::thanatos::infrastructure::presentation

--- a/src/infrastructure/terminal/Console.cpp
+++ b/src/infrastructure/terminal/Console.cpp
@@ -1,0 +1,36 @@
+#include "infrastructure/terminal/Console.hpp"
+
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif
+
+namespace arkan::thanatos::infrastructure::terminal
+{
+bool locale_is_utf8()
+{
+#if defined(_WIN32)
+    // If VT mode is available, we assume the console can show UTF-8.
+    // VTモードが使えればUTF-8表示可能とみなす。
+    return true;
+#else
+    // On POSIX we assume UTF-8 locale (customize as needed).
+    // POSIXではUTF-8ロケールを仮定（必要なら拡張）。
+    return true;
+#endif
+}
+
+void enable_vt_sequences_if_possible()
+{
+#if defined(_WIN32)
+    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (hOut == INVALID_HANDLE_VALUE) return;
+    DWORD mode = 0;
+    if (!GetConsoleMode(hOut, &mode)) return;
+    mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    SetConsoleMode(hOut, mode);
+#endif
+}
+}  // namespace arkan::thanatos::infrastructure::terminal

--- a/src/infrastructure/terminal/Console.hpp
+++ b/src/infrastructure/terminal/Console.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace arkan::thanatos::infrastructure::terminal
+{
+// Detect console UTF-8 capability (best effort).
+// コンソールのUTF-8対応を判定（ベストエフォート）。
+bool locale_is_utf8();
+
+// Enable Windows VT sequences if possible (no-op on POSIX).
+// WindowsのVTシーケンスを可能なら有効化（POSIXでは何もしない）。
+void enable_vt_sequences_if_possible();
+}  // namespace arkan::thanatos::infrastructure::terminal

--- a/src/infrastructure/terminal/Output.hpp
+++ b/src/infrastructure/terminal/Output.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstdio>
+#include <string>
+#include <string_view>
+
+#if defined(_WIN32)
+#include "shared/BannerPrinter.hpp"
+#endif
+
+namespace arkan::thanatos::infrastructure::terminal
+{
+// Emit a raw UTF-8 line with platform-friendly newline.
+// プラットフォーム互換の改行付きでUTF-8行を出力。
+inline void emit_utf8_line(std::string_view utf8)
+{
+#if defined(_WIN32)
+    arkan::thanatos::shared::print_utf8_banner(std::string(utf8));
+    arkan::thanatos::shared::print_utf8_banner(std::string("\r\n"));
+#else
+    std::fwrite(utf8.data(), 1, utf8.size(), stdout);
+    std::fwrite("\n", 1, 1, stdout);
+#endif
+}
+
+// Emit a plain ASCII line (fast path).
+// ASCII行をそのまま出力。
+inline void emit_ascii_line(std::string_view ascii)
+{
+    std::fwrite(ascii.data(), 1, ascii.size(), stdout);
+    std::fwrite("\n", 1, 1, stdout);
+}
+
+// Emit a blank line.
+// 空行を出力。
+inline void emit_blank_line()
+{
+    std::fwrite("\n", 1, 1, stdout);
+}
+
+// Print a whole blob as-is (no extra newline).
+// 生文字列をそのまま出力（改行追加なし）。
+inline void print_portable(std::string_view blob)
+{
+#if defined(_WIN32)
+    arkan::thanatos::shared::print_utf8_banner(std::string(blob));
+#else
+    std::fwrite(blob.data(), 1, blob.size(), stdout);
+#endif
+}
+}  // namespace arkan::thanatos::infrastructure::terminal

--- a/src/infrastructure/terminal/Output.hpp
+++ b/src/infrastructure/terminal/Output.hpp
@@ -23,14 +23,6 @@ inline void emit_utf8_line(std::string_view utf8)
 #endif
 }
 
-// Emit a plain ASCII line (fast path).
-// ASCII行をそのまま出力。
-inline void emit_ascii_line(std::string_view ascii)
-{
-    std::fwrite(ascii.data(), 1, ascii.size(), stdout);
-    std::fwrite("\n", 1, 1, stdout);
-}
-
 // Emit a blank line.
 // 空行を出力。
 inline void emit_blank_line()

--- a/src/interface/query/QueryServer.cpp
+++ b/src/interface/query/QueryServer.cpp
@@ -138,8 +138,8 @@ struct QueryServer::Impl
                                  async_accept();
                                  return;
                              }
-                             Logger::info(std::string("[bus] client connected from ") +
-                                          sock->remote_endpoint().address().to_string());
+                             Logger::debug(std::string("[bus] client connected from ") +
+                                           sock->remote_endpoint().address().to_string());
                              read_len();
                          });
     }
@@ -211,12 +211,12 @@ struct QueryServer::Impl
                             if (on_query)
                             {
                                 const auto& blob = it->second.bin;
-                                Logger::info(banner("RX←THANATOS", "Thanatos Query", blob.size()));
+                                Logger::debug(banner("RX←THANATOS", "Thanatos Query", blob.size()));
                                 if (blob.size() >= 4 && (blob[0] | (blob[1] << 8)) >= 0x0001)
                                 {
-                                    Logger::info("(raw) no RO header");
+                                    Logger::debug("(raw) no RO header");
                                 }
-                                Logger::info("\n" + hex_dump(blob.data(), blob.size()));
+                                Logger::debug("\n" + hex_dump(blob.data(), blob.size()));
 
                                 on_query(it->second.bin);
                             }
@@ -325,8 +325,8 @@ void QueryServer::sendReply(const std::vector<uint8_t>& gg_reply)
     Logger::debug("[bus] tx Thanatos Reply payload head32=" + head_bus +
                   " len=" + std::to_string(gg_reply.size()));
 
-    Logger::info(banner("TX→THANATOS", "Thanatos Reply", gg_reply.size()));
-    Logger::info("\n" + hex_dump(gg_reply.data(), gg_reply.size()));
+    Logger::debug(banner("TX→THANATOS", "Thanatos Reply", gg_reply.size()));
+    Logger::debug("\n" + hex_dump(gg_reply.data(), gg_reply.size()));
 
     impl_->send_reply_bin(gg_reply);
 }

--- a/src/shared/BuildInfo.hpp
+++ b/src/shared/BuildInfo.hpp
@@ -24,8 +24,8 @@ inline constexpr std::string_view kBuildProfile =
 
 // Render signature card and return {blob, inner_width}.
 // シグネチャカードを描画して {文字列, 内部幅} を返す。
-inline std::pair<std::string, int> build_signature_footer_with_width(bool color = true,
-                                                                     bool utf8Box = true)
+inline std::pair<std::string, int> build_signature_with_width(bool color = true,
+                                                              bool utf8Box = true)
 {
     using namespace std::string_literals;
 
@@ -104,12 +104,5 @@ inline std::pair<std::string, int> build_signature_footer_with_width(bool color 
 
     out += "\n";
     return {out, inner};
-}
-
-// Keep old API for compatibility.
-// 互換性のため旧APIも提供。
-inline std::string build_signature_footer(bool color = true, bool utf8Box = true)
-{
-    return build_signature_footer_with_width(color, utf8Box).first;
 }
 }  // namespace arkan::thanatos::shared

--- a/src/shared/BuildInfo.hpp
+++ b/src/shared/BuildInfo.hpp
@@ -1,12 +1,20 @@
 #pragma once
 
+#include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
+
+#include "shared/terminal/Ansi.hpp"
+#include "shared/terminal/TextWidth.hpp"
+#include "shared/terminal/Utf8.hpp"
 
 namespace arkan::thanatos::shared
 {
+namespace term = arkan::thanatos::shared::terminal;
 
 inline constexpr std::string_view kProjectName = "Thanatos";
-inline constexpr std::string_view kVersion = "0.1.2";
+inline constexpr std::string_view kVersion = "0.1.3";
 inline constexpr std::string_view kBuildProfile =
 #if defined(NDEBUG)
     "Release";
@@ -14,39 +22,94 @@ inline constexpr std::string_view kBuildProfile =
     "Debug";
 #endif
 
-inline constexpr std::string_view kSignature = R"(
-⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⡀⠀⠀⠀⢀⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
-⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣠⣤⣶⣾⣿⡉⢤⣍⡓⢶⣶⣦⣤⣉⠒⠤⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
-⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣴⣿⣿⣿⣿⣿⣿⣷⡀⠙⣿⣷⣌⠻⣿⣿⣿⣶⣌⢳⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀
-⠀⠀⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣄⠈⢿⣿⡆⠹⣿⣿⣿⣿⣷⣿⡀⠀⠀⠀⠀⠀⠀⠀⠀
-⠀⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⣄⠹⣿⡄⢻⣿⣿⣿⣿⣿⣧⠀⠀⠀⠀⠀⠀⠀⠀
-⠀⠀⠀⠀⠀⠀⢠⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⠿⣿⣿⣷⣽⣷⢸⣿⡿⣿⡿⠿⠿⣆⠀⠀⠀⠀⠀⠀⠀
-⠀⠀⠀⠀⠀⠀⣼⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡄⠀⠀⠀⠐⠾⢭⣭⡼⠟⠃⣤⡆⠘⢟⢺⣦⡀⠀⠀⠀⠀⠀
-⠀⠀⠀⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⢛⣥⣶⠾⠿⠛⠳⠶⢬⡁⠀⠀⠘⣃⠤⠤⠤⢍⠻⡄⠀⠀⠀⠀
-⠀⠀⠀⠀⠀⠀⣿⣿⣿⣿⣿⣿⡿⣫⣾⡿⢋⣥⣶⣿⠿⢿⣿⣿⣿⣿⠩⠭⢽⣷⡾⢿⣿⣦⢱⡹⡀⠀⠀⠀
-⠀⠀⠀⠀⠀⠀⣿⣿⣿⣿⣿⣿⡟⠈⠛⠏⠰⢿⣿⣿⣧⣤⣼⣿⣿⣿⡏⠩⠽⣿⣀⣼⣿⣿⢻⣷⢡⠀⠀⠀
-⠀⠀⠀⠀⠀⢰⣿⣿⣿⣿⣿⣿⢁⣿⣷⣦⡀⠀⠉⠙⠛⠛⠛⠋⠁⠙⢻⡆⠀⢌⣉⠉⠉⠀⠸⣿⣇⠆⠀⠀
-⠀⠀⠀⠀⢀⣾⣿⣿⣿⣿⣿⡇⢸⣿⣿⣿⣿⠷⣄⢠⣶⣾⣿⣿⣿⣿⣿⠁⠀⠀⢿⣿⣿⣿⣷⠈⣿⠸⡀⠀
-⠀⠀⠀⠀⣼⣿⣿⣿⣿⣿⣿⠀⣌⡛⠿⣿⣿⠀⠈⢧⢿⣿⡿⠟⠋⠉⣠⣤⣤⣤⣄⠙⢿⣿⠏⣰⣿⡇⢇⠀
-⠀⠀⠀⣼⣿⣿⣿⣿⣿⣿⡇⢸⣿⣿⣶⣤⣙⠣⢀⠈⠘⠏⠀⠀⢀⣴⢹⡏⢻⡏⣿⣷⣄⠉⢸⣿⣿⣷⠸⡄
-⠀⠀⣸⣿⣿⣿⣿⣿⣿⣿⠁⣾⣟⣛⠛⠛⠻⠿⠶⠬⠔⠀⣠⡶⠋⠿⠈⠷⠸⠇⠻⠏⠻⠆⣀⢿⣿⣿⡄⢇
-⠀⢰⣿⣿⣿⣿⠿⠿⠛⠋⣰⣿⣿⣿⣿⠿⠿⠿⠒⠒⠂⠀⢨⡤⢶⣶⣶⣶⣶⣶⣶⣶⣶⠆⠃⣀⣿⣿⡇⣸
-⢀⣿⣿⠿⠋⣡⣤⣶⣾⣿⣿⣿⡟⠁⠀⣠⣤⣴⣶⣶⣾⣿⣿⣷⡈⢿⣿⣿⣿⣿⠿⠛⣡⣴⣿⣿⣿⣿⠟⠁
-⣼⠋⢁⣴⣿⣿⣿⣿⣿⣿⣿⣿⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣎⠻⠟⠋⣠⣴⣿⣿⣿⣿⠿⠋⠁⠀⠀
-⢿⣷⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠀⣴⠀⠻⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣧⣠⣾⣿⠿⠿⠟⠋⠁⠀⠀⠀⠀⠀
-⠀⠉⠛⠛⠿⠿⠿⢿⣿⣿⣿⣵⣾⣿⣧⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠏⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
-)";
+// Render signature card and return {blob, inner_width}.
+// シグネチャカードを描画して {文字列, 内部幅} を返す。
+inline std::pair<std::string, int> build_signature_footer_with_width(bool color = true,
+                                                                     bool utf8Box = true)
+{
+    using namespace std::string_literals;
 
-inline constexpr std::string_view kSignatureFooter =
-    R"(
-//
-//  ⚔  Forged in chaos. Delivered with precision.
-//
-//  Author : Rhayden - Arkan Software
-//  Email  : Rhayden@arkansoftware.com
-//  Github : https://github.com/MarcoRhayden/thanatos
-//
+    // Colors
+    const auto B = color ? std::string(ansi::bold) : ""s;
+    const auto D = color ? std::string(ansi::dim) : ""s;
+    const auto R = color ? std::string(ansi::red) : ""s;
+    const auto G = color ? std::string(ansi::green) : ""s;
+    const auto C = color ? std::string(ansi::cyan) : ""s;
+    const auto Y = color ? std::string(ansi::yellow) : ""s;
+    const auto M = color ? std::string(ansi::mag) : ""s;
+    const auto W = color ? std::string(ansi::white) : ""s;
+    const auto RS = color ? std::string(ansi::reset) : ""s;
 
-)";
+    // Lines (content only).
+    const auto title = B + R + std::string(kProjectName) + RS + " " + D + "(" +
+                       std::string(kBuildProfile) + ")" + RS;
+    const auto tagline = "⚔  Forged in chaos. Delivered with precision.";
+    const auto vline = C + "Version" + RS + ": " + B + std::string(kVersion) + RS;
+    const auto auth = C + "Author " + RS + ": " + "Rhayden – Arkan Software";
+    const auto mail = C + "Email  " + RS + ": " + Y + "Rhayden@arkansoftware.com" + RS;
+    const auto git =
+        C + "Github " + RS + ": " + M + "https://github.com/MarcoRhayden/thanatos" + RS;
 
+    std::vector<std::string> content{title, tagline, vline, auth, mail, git};
+    int inner = 0;
+    for (auto& s : content)
+        inner = std::max(inner, static_cast<int>(term::visible_width_utf8(term::strip_ansi(s))));
+
+    const int pad_lr = 2;
+    const int box_w = inner + pad_lr * 2;
+
+    auto padLine = [&](const std::string& raw)
+    {
+        int vis = static_cast<int>(term::visible_width_utf8(term::strip_ansi(raw)));
+        int pad = std::max(0, inner - vis);
+        return std::string(pad_lr, ' ') + raw + std::string(pad, ' ') + std::string(pad_lr, ' ');
+    };
+
+    std::string out;
+    out.reserve(256);
+    out += "\n";
+
+    if (utf8Box)
+    {
+        const std::string top = "┌" + term::repeat_utf8("─", box_w) + "┐\n";
+        const std::string sep = "├" + term::repeat_utf8("─", box_w) + "┤\n";
+        const std::string bot = "└" + term::repeat_utf8("─", box_w) + "┘\n";
+
+        out += top;
+        out += "│" + padLine(W + title + RS) + "│\n";
+        out += "│" + padLine(std::string(ansi::dim) + tagline + RS) + "│\n";
+        out += sep;
+        out += "│" + padLine(vline) + "│\n";
+        out += "│" + padLine(auth) + "│\n";
+        out += "│" + padLine(mail) + "│\n";
+        out += "│" + padLine(git) + "│\n";
+        out += bot;
+    }
+    else
+    {
+        const std::string top = "+" + std::string(box_w, '-') + "+\n";
+        const std::string sep = "+" + std::string(box_w, '-') + "+\n";
+        const std::string bot = "+" + std::string(box_w, '-') + "+\n";
+
+        out += top;
+        out += "|" + padLine(W + title + RS) + "|\n";
+        out += "|" + padLine(std::string(ansi::dim) + tagline + RS) + "|\n";
+        out += sep;
+        out += "|" + padLine(vline) + "|\n";
+        out += "|" + padLine(auth) + "|\n";
+        out += "|" + padLine(mail) + "|\n";
+        out += "|" + padLine(git) + "|\n";
+        out += bot;
+    }
+
+    out += "\n";
+    return {out, inner};
+}
+
+// Keep old API for compatibility.
+// 互換性のため旧APIも提供。
+inline std::string build_signature_footer(bool color = true, bool utf8Box = true)
+{
+    return build_signature_footer_with_width(color, utf8Box).first;
+}
 }  // namespace arkan::thanatos::shared

--- a/src/shared/terminal/Ansi.hpp
+++ b/src/shared/terminal/Ansi.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <string_view>
+
+namespace arkan::thanatos::shared::ansi
+{
+// Basic ANSI SGR tokens.
+// 端末のANSIカラー用トークン。
+inline constexpr std::string_view reset = "\x1b[0m";
+inline constexpr std::string_view bold = "\x1b[1m";
+inline constexpr std::string_view dim = "\x1b[2m";
+
+inline constexpr std::string_view red = "\x1b[31m";
+inline constexpr std::string_view green = "\x1b[32m";
+inline constexpr std::string_view yellow = "\x1b[33m";
+inline constexpr std::string_view blue = "\x1b[34m";
+inline constexpr std::string_view mag = "\x1b[35m";
+inline constexpr std::string_view cyan = "\x1b[36m";
+inline constexpr std::string_view white = "\x1b[37m";
+}  // namespace arkan::thanatos::shared::ansi

--- a/src/shared/terminal/Ansi.hpp
+++ b/src/shared/terminal/Ansi.hpp
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <string_view>
 
 namespace arkan::thanatos::shared::ansi

--- a/src/shared/terminal/TextWidth.hpp
+++ b/src/shared/terminal/TextWidth.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace arkan::thanatos::shared::terminal
+{
+// Strip ANSI CSI sequences roughly: \x1b[ ... 'm'.
+// ANSIシーケンス（ざっくり）を取り除く。
+inline std::string strip_ansi(std::string_view s)
+{
+    std::string out;
+    out.reserve(s.size());
+    for (size_t i = 0; i < s.size(); ++i)
+    {
+        if (s[i] == '\x1b')
+        {
+            // skip until 'm'
+            while (i < s.size() && s[i] != 'm') ++i;
+            continue;
+        }
+        out.push_back(s[i]);
+    }
+    return out;
+}
+
+// Visible width of a UTF-8 string in terminal columns (simple).
+// 端末の見かけ幅（簡易版）。全角幅は未対応の簡易実装。
+inline size_t visible_width_utf8(std::string_view s)
+{
+    // Very simple: count bytes, assume 1 col per code point.
+    // 実運用で拡張するなら、EastAsianWidth を考慮する。
+    // Here we naïvely count non-continuation bytes.
+    size_t cols = 0;
+    for (size_t i = 0; i < s.size(); ++i)
+    {
+        unsigned char c = static_cast<unsigned char>(s[i]);
+        if ((c & 0xC0) != 0x80) ++cols;  // count head bytes
+    }
+    return cols;
+}
+}  // namespace arkan::thanatos::shared::terminal

--- a/src/shared/terminal/TextWidth.hpp
+++ b/src/shared/terminal/TextWidth.hpp
@@ -30,7 +30,6 @@ inline size_t visible_width_utf8(std::string_view s)
 {
     // Very simple: count bytes, assume 1 col per code point.
     // 実運用で拡張するなら、EastAsianWidth を考慮する。
-    // Here we naïvely count non-continuation bytes.
     size_t cols = 0;
     for (size_t i = 0; i < s.size(); ++i)
     {

--- a/src/shared/terminal/Utf8.hpp
+++ b/src/shared/terminal/Utf8.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace arkan::thanatos::shared::terminal
+{
+// Repeat a UTF-8 glyph n times.
+// UTF-8グリフをn回繰り返す。
+inline std::string repeat_utf8(std::string_view g, size_t n)
+{
+    std::string out;
+    out.reserve(g.size() * n);
+    for (size_t i = 0; i < n; ++i) out += g;
+    return out;
+}
+}  // namespace arkan::thanatos::shared::terminal

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "thanatos",
-  "version-string": "0.1.2",
+  "version-string": "0.1.3",
   "dependencies": [
     "boost-system",
     "boost-asio",


### PR DESCRIPTION
# Thanatos v0.1.3 — Release Notes

> ⚔ Forged in chaos. Delivered with precision.

## Highlights

- **New terminal banners** with consistent width, crisp UTF-8 box drawing, and ANSI color.
- **Unified card layout**: the startup summary now matches the signature card width and style.
- **GameGuard Bridge**: smarter reliability with **configurable retries** and **per-attempt randomized timeouts**.
- **Cleaner code structure**: extracted utilities for card rendering and terminal output.
- **Safer Windows console defaults**: VT/UTF-8 enabled when possible for proper colors and glyphs.